### PR TITLE
Replace shebang for portability sake

### DIFF
--- a/gh-repo-topic
+++ b/gh-repo-topic
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # List and add repository topics.
 set -e
 


### PR DESCRIPTION
The used shebang (#!/bin/bash)
has greater chance to fail (as it does on NixOS, for example).

en.wikipedia.org/w/index.php?title=Shebang_(Unix)&oldid=878552871#Portability